### PR TITLE
Changes for PHP 7.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.0.0",
         "guzzlehttp/guzzle": "^6.3"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "632cf084e4b3cc3394c00f7d2b2c3297",
+    "content-hash": "5ae8d208b84799dca9425af8f8a0e85b",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -245,7 +245,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.0"
+        "php": ">=7.0.0"
     },
     "platform-dev": []
 }

--- a/src/ElasticEmailClient/ApiConfiguration.php
+++ b/src/ElasticEmailClient/ApiConfiguration.php
@@ -3,7 +3,7 @@
 
     class ApiConfiguration
     {
-        public const AVAILABLE_REQUEST_METHODS = ['GET', 'POST'];
+        const AVAILABLE_REQUEST_METHODS = ['GET', 'POST'];
 
         /**
          * @var string


### PR DESCRIPTION
Thanks for creating this library! We ran into an issue using it with PHP 7, and where hoping to merge the following change:

Drop the "public" visibility on the AVAILABLE_REQUEST_METHODS constant, as this is only available in PHP 7.1 (and public is the current default behaviour).

Mark the minimum version of PHP as 7.0.0 in composer.json, as several PHP 7 features are used in the project, such as scalar type hints.