### PR TITLE
Fix "Undefined property: stdClass::$data" error in domain/add API call

### DIFF
--- a/src/ElasticEmailClient/ElasticRequest.php
+++ b/src/ElasticEmailClient/ElasticRequest.php
@@ -69,7 +69,7 @@
                 throw new \Exception($resp->error);
             }
 
-            if (isset($resp->data)) {
+            if (isset($resp->data) && $resp->data) {
                 return $resp->data;
             }
              

--- a/src/ElasticEmailClient/ElasticRequest.php
+++ b/src/ElasticEmailClient/ElasticRequest.php
@@ -37,10 +37,10 @@
         {
             $method = strtoupper($method);
 
-                    if (!in_array($method, \ElasticEmailClient\ApiConfiguration::AVAILABLE_REQUEST_METHODS))
-                    {
-                        throw new \Exception('Unallowed request method type');
-                    }
+            if (!in_array($method, ApiConfiguration::AVAILABLE_REQUEST_METHODS))
+            {
+                throw new \Exception('Unallowed request method type');
+            }
 
             $options = [];
             $data['apikey'] = $this->configuration->getApiKey();
@@ -69,7 +69,9 @@
                 throw new \Exception($resp->error);
             }
 
-            if ($resp->data) { return $resp->data; }
+            if (isset($resp->data)) {
+                return $resp->data;
+            }
              
             return $resp;
         }


### PR DESCRIPTION
Hi there,

We where encountering an "Undefined property: stdClass::$data" notice, when calling the "https://api.elasticemail.com/v2/domain/add" endpoint.

The API call was successful, but because the API call doesn't return any data, the "if ($resp->data) {" check results in the Undefined property notice in PHP - unfortunately this causes Symfony to throw an exception.

This PR simply adds an additional "isset" call, to prevent this notice.

Please do let me know if you require any other information regarding this.

Thanks!