### PR TITLE
Reusable configuration keys

### DIFF
--- a/src/ElasticEmailClient/ApiConfiguration.php
+++ b/src/ElasticEmailClient/ApiConfiguration.php
@@ -31,10 +31,14 @@
          * ApiConfiguration constructor.
          * @param array $params
          */
-        public function __construct(array $params)
+        public function __construct(array $params = [])
         {
-            $this->setApiKey($params[self::API_KEY]);
-            $this->setApiUrl($params[self::API_URL]);
+            if (isset($params[self::API_KEY])) {
+                $this->setApiKey($params[self::API_KEY]);
+            }
+            if (isset($params[self::API_URL])) {
+                $this->setApiUrl($params[self::API_URL]);
+            }
         }
 
         /**

--- a/src/ElasticEmailClient/ApiConfiguration.php
+++ b/src/ElasticEmailClient/ApiConfiguration.php
@@ -4,6 +4,8 @@
     class ApiConfiguration
     {
         const AVAILABLE_REQUEST_METHODS = ['GET', 'POST'];
+        const API_KEY = 'apiKey';
+        const API_URL = 'apiUrl';
 
         /**
          * @var string
@@ -31,8 +33,8 @@
          */
         public function __construct(array $params)
         {
-            $this->setApiKey($params['apiKey']);
-            $this->setApiUrl($params['apiUrl']);
+            $this->setApiKey($params[self::API_KEY]);
+            $this->setApiUrl($params[self::API_URL]);
         }
 
         /**


### PR DESCRIPTION
1. It's not so useful to initialize client with string configuration keys, as your examples:
```php
    $configuration = new \ElasticEmailClient\ApiConfiguration([
        'apiUrl' => 'https://api.elasticemail.com/v2/',
        'apiKey' => 'yourApiKey'
    ]);
```
More useful:
```php
    $configuration = new \ElasticEmailClient\ApiConfiguration([
        \ElasticEmailClient\ApiConfiguration::API_URL => 'https://api.elasticemail.com/v2/',
        \ElasticEmailClient\ApiConfiguration::API_KEY => 'yourApiKey'
    ]);
```

2. I think it is better to pass this options via setters and not to do them as required arguments of constructor:
```php
$config = new ApiConfiguration();
$config
            ->setApiUrl($apiUrl)
            ->setApiKey($api);
```
If you do not agree with me I can remove this commit https://github.com/ElasticEmail/ElasticEmail.WebApiClient-php/pull/14/commits/478eb7321d555025eae0e0436313ad9ed98c61c7